### PR TITLE
Update interface to use NQCBase.Structure type. 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCDInterfASE"
 uuid = "4606675f-2246-4a0b-99d5-75b910de637b"
 authors = ["Alexander Spears <alexander.spears@warwick.ac.uk> and contributors"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
@@ -13,7 +13,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
 CondaPkg = "0.2.29"
-NQCBase = "0.5, 1"
+NQCBase = "1.1"
 NQCModels = "0.10, 1"
 PythonCall = "0.9"
 Unitful = "1.22"

--- a/src/NQCDInterfASE.jl
+++ b/src/NQCDInterfASE.jl
@@ -10,16 +10,20 @@ using Unitful, UnitfulAtomic
 export convert_from_ase_atoms
 export convert_to_ase_atoms
 
-const ase = PythonCall.pyimport("ase")
+# Updated method to load Python packages with newer PythonCall versions. 
+const ase = Ref{Py}()
+function __init__()
+	ase[] = pyimport("ase")
+end
 
 convert_to_ase_atoms(atoms::Atoms, R::Matrix) =
-	ase.Atoms(positions=ustrip.(u"Å", R'u"bohr"), symbols=string.(atoms.types))
+	ase[].Atoms(positions=ustrip.(u"Å", R'u"bohr"), symbols=string.(atoms.types))
 
 convert_to_ase_atoms(atoms::Atoms, R::Matrix, ::InfiniteCell) =
 	convert_to_ase_atoms(atoms, R)
 
 function convert_to_ase_atoms(atoms::Atoms, R::Matrix, cell::PeriodicCell)
-	ase.Atoms(
+	ase[].Atoms(
 		positions=ustrip.(u"Å", R'u"bohr"),
 		cell=ustrip.(u"Å", cell.vectors'u"bohr"),
 		symbols=string.(atoms.types),

--- a/src/NQCDInterfASE.jl
+++ b/src/NQCDInterfASE.jl
@@ -1,7 +1,7 @@
 module NQCDInterfASE
 
 using PythonCall
-using NQCBase: Atoms, AbstractCell, PeriodicCell, InfiniteCell
+using NQCBase
 import NQCModels
 using Unitful, UnitfulAtomic
 
@@ -37,7 +37,7 @@ end
 convert_from_ase_atoms(ase_atoms::PythonCall.Py) =
 	Atoms(ase_atoms), positions(ase_atoms), Cell(ase_atoms)
 
-Atoms(ase_atoms::PythonCall.Py) = Atoms{Float64}(Symbol.(PythonCall.PyList(ase_atoms.get_chemical_symbols())))
+NQCBase.Atoms(ase_atoms::PythonCall.Py) = Atoms{Float64}(Symbol.(PythonCall.PyList(ase_atoms.get_chemical_symbols())))
 
 positions(ase_atoms::PythonCall.Py) = austrip.(PythonCall.PyArray(ase_atoms.get_positions())'u"Å")
 

--- a/src/NQCDInterfASE.jl
+++ b/src/NQCDInterfASE.jl
@@ -35,7 +35,7 @@ function convert_to_ase_atoms(atoms::Atoms, R::Vector{<:Matrix}, cell::AbstractC
 end
 
 convert_from_ase_atoms(ase_atoms::PythonCall.Py) =
-	Atoms(ase_atoms), positions(ase_atoms), Cell(ase_atoms)
+	NQCBase.Structure(Atoms(ase_atoms), positions(ase_atoms), Cell(ase_atoms))
 
 NQCBase.Atoms(ase_atoms::PythonCall.Py) = Atoms{Float64}(Symbol.(PythonCall.PyList(ase_atoms.get_chemical_symbols())))
 

--- a/test/ase.jl
+++ b/test/ase.jl
@@ -9,13 +9,13 @@ using PythonCall
     R = rand(3, 4) .* 10
 
     ase_atoms = convert_to_ase_atoms(atoms, R, cell)
-    new_atoms, new_R, new_cell = convert_from_ase_atoms(ase_atoms)
+    nqcd_structure = convert_from_ase_atoms(ase_atoms)
     
-    @test new_atoms == atoms
-    @test new_cell.vectors ≈ cell.vectors
-    @test new_cell.inverse ≈ cell.inverse
-    @test new_cell.periodicity ≈ cell.periodicity
-    @test new_R ≈ R
+    @test nqcd_structure.atoms == atoms
+    @test nqcd_structure.cell.vectors ≈ cell.vectors
+    @test nqcd_structure.cell.inverse ≈ cell.inverse
+    @test nqcd_structure.cell.periodicity ≈ cell.periodicity
+    @test nqcd_structure.positions ≈ R
 end
 
 @testset "Multiple frames" begin
@@ -25,5 +25,14 @@ end
 
     ase_atoms = convert_to_ase_atoms(atoms, R, cell)
     out = convert_from_ase_atoms.(ase_atoms)
-    @test out isa Vector{<:Tuple}
+    # Correct types
+    @test out isa Vector{<:NQCBase.Structure}
+    for frame in structure
+        nqcd_structure = frame
+        @test nqcd_structure.atoms == atoms
+        @test nqcd_structure.cell.vectors ≈ cell.vectors
+        @test nqcd_structure.cell.inverse ≈ cell.inverse
+        @test nqcd_structure.cell.periodicity ≈ cell.periodicity
+        @test nqcd_structure.positions ≈ R
+    end
 end

--- a/test/ase.jl
+++ b/test/ase.jl
@@ -27,12 +27,12 @@ end
     out = convert_from_ase_atoms.(ase_atoms)
     # Correct types
     @test out isa Vector{<:NQCBase.Structure}
-    for frame in structure
+    for (frame, positions) in zip(out, R)
         nqcd_structure = frame
         @test nqcd_structure.atoms == atoms
         @test nqcd_structure.cell.vectors ≈ cell.vectors
         @test nqcd_structure.cell.inverse ≈ cell.inverse
         @test nqcd_structure.cell.periodicity ≈ cell.periodicity
-        @test nqcd_structure.positions ≈ R
+        @test nqcd_structure.positions ≈ positions
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using NQCDInterfaceASE
+using NQCDInterfASE
 using Test
 
 include("ase.jl")


### PR DESCRIPTION
If we add a `Structure` type to NQCBase [PR](https://github.com/NQCD/NQCBase.jl/pull/29), the ASE interface should return converted structures in this type, and support direct conversion as well as conversion from individual atoms, positions and cells. 

**This PR makes breaking changes compared to previous versions - reflect
this in version changes**

- [x] Update NQCD Docs in NQCDynamics.jl. 
- [x] Make sure unit tests work. 