### PR TITLE
👽 Enable ASE atoms conversion from juliacall.

### DIFF
--- a/src/NQCDInterfASE.jl
+++ b/src/NQCDInterfASE.jl
@@ -34,7 +34,7 @@ function convert_to_ase_atoms(atoms::Atoms, R::Vector{<:Matrix}, cell::AbstractC
 	convert_to_ase_atoms.(Ref(atoms), R, Ref(cell))
 end
 
-convert_from_ase_atoms(ase_atoms::PythonCall.Py) =
+convert_from_ase_atoms(ase_atoms::Union{PythonCall.Py, PythonCall.PyIterable}) =
 	NQCBase.Structure(Atoms(ase_atoms), positions(ase_atoms), Cell(ase_atoms))
 
 NQCBase.Atoms(ase_atoms::PythonCall.Py) = Atoms{Float64}(Symbol.(PythonCall.PyList(ase_atoms.get_chemical_symbols())))


### PR DESCRIPTION
The `juliacall` Python package converts `ase.atoms` into `PyIterable{Any}` types in Julia, for which there currently isn’t a `convert_from_ase_atoms` method defined. 

This PR adds an additional method for this, so NQCDInterfASE can be used to convert structures back and forth between Python and Julia. 